### PR TITLE
Ajout du package ncp pour pouvoir effectuer une copie 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf dist/controller && rimraf dist/model && rimraf dist/routes && rimraf dist/App.js && rimraf dist/index.js",
     "compile": "npm run compile:ts",
     "compile:ts": "tsc --outDir ./dist --module commonjs --downlevelIteration ./src/index.ts",
-    "copydata": "cp -R src/data dist/data"
+    "copydata": "ncp src/data dist/data"
   },
   "watch": {
     "test": "{src,tests}/*.js"
@@ -36,6 +36,7 @@
     "debug": "^4.3.5",
     "jest": "^29.7.0",
     "jest-config": "^29.7.0",
+    "ncp": "^2.0.0",
     "npm-watch": "^0.13.0",
     "rimraf": "^5.0.7",
     "supertest": "^7.0.0",


### PR DESCRIPTION
Le SGB échoue son démarrage sous Windows.

![image](https://github.com/profcfuhrmanets/log210-systeme-gestion-bordereau-node-express-ts/assets/2374739/dd0ec9be-67bb-44dd-b9fe-c50fc2ecf366)

Ceci est du au fait que la commande npm "copydata" qui est exécutée assume un système d'exploitation Linux (ou WSL). Cette commande devrait fonctionner sur MacOS également, mais je ne peut pas valider (je n'ai pas de Mac).

Une solution possible est d'installer un package comme "ncp", et de modifier la commande dans le package.json
