### PR TITLE
Mettre à jour la documentation pour récupérer les étudiants

### DIFF
--- a/src/routes/StudentRouter.ts
+++ b/src/routes/StudentRouter.ts
@@ -92,9 +92,9 @@ export class StudentRouter
         this.router.get('/login', this.login.bind(this));
 
         /**
-        * @api {get} /api/v3/student/all Récupérer tous les enseignants
+        * @api {get} /api/v3/student/all Récupérer tous les étudiants
         * @apiGroup Student
-        * @apiDescription Récupérer tous les enseignants.
+        * @apiDescription Récupérer tous les étudiants.
         * @apiVersion 3.0.0
         * @apiSuccess (200) {JSON}  data [{
         *   first_name: string,


### PR DESCRIPTION
Dans la documentation actuelle, en lien avec les étudiants, il est indiqué par erreur de récupérer "tous les enseignants".

![image](https://github.com/user-attachments/assets/f6029ff8-df23-4120-b323-3bca0a3e4ec9)

J'ai mis à jour le code, mais il faudra aussi mettre à jour l'API doc qui est hébergé sur Git.