### PR TITLE
Générer un message d'erreur pour indiquer qu'il s'agit de la doc qui manque

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -69,7 +69,11 @@ class App
         this.express.use('/', router);
         this.express.use(function(req:Request, res:Response)
         {
-            throw new NotFoundError("La route demandée n'existe pas.");
+            let errorMessage = "La route demandée n'existe pas.";
+            if (req.path.startsWith('/docs')) {
+                errorMessage += " Veuillez noter que la documentation doit être générée la première fois avec la commande `npm run all_docs`.";
+            }
+            throw new NotFoundError(errorMessage);    
         });
     }
 


### PR DESCRIPTION
Le fichier README.md indique bien qu'il faut faire `npm run all_docs`… avant de faire `npm run start` la première fois. Mais, j'ai ajouté un message d'erreur pour le cas où on oublie de le faire.

Fixes #35